### PR TITLE
Generic test component for alloc.v

### DIFF
--- a/Fomu/verilog/bench/alloc_tb.v
+++ b/Fomu/verilog/bench/alloc_tb.v
@@ -6,7 +6,7 @@ Test Bench for alloc.v
 
 `default_nettype none
 
-`include "alloc.v"
+`include "alloc_test.v"
 
 `timescale 10ns/1ns
 
@@ -16,7 +16,7 @@ module test_bench;
     initial begin
         $dumpfile("alloc.vcd");
         $dumpvars(0, test_bench);
-        #1600;
+        #1000;
         $finish;
     end
 
@@ -26,77 +26,13 @@ module test_bench;
         #1 clk = !clk;
     end
 
-    // instantiate allocator
-    wire [15:0] alloc_addr;
-    alloc #(
-        .ADDR_SZ(4)
-    ) ALLOC (
+    wire running;
+    wire pass;
+    alloc_test TEST (
         .i_clk(clk),
-        .i_alloc(alloc_stb),
-        .i_data(UNDEF),
-        .o_addr(alloc_addr),
-        .i_free(free_stb),
-        .i_addr(free_addr),
-        .i_wr(1'b0),
-        .i_rd(1'b0)
+        .i_en(1'b1),
+        .o_running(running),
+        .o_pass(pass)
     );
-
-/*
-    // request allocation every 13 clocks
-    reg alloc_stb;  // allocation request
-    initial alloc_stb = 1'b0;
-    reg [3:0] alloc_cnt;
-    initial alloc_cnt = 13;
-    always @(posedge clk) begin
-        if (alloc_cnt == 0) begin
-            alloc_cnt <= 13;  // reset counter
-            alloc_stb <= 1'b1;  // request strobe
-        end else begin
-            alloc_cnt <= alloc_cnt - 1'b1;  // decrement counter
-            alloc_stb <= 1'b0;  // clear request
-        end
-    end
-*/
-
-    // FIXME: move definitions to an include file?
-    localparam UNDEF            = 16'h0000;                     // undefined value
-
-    // script control signals
-    reg alloc_stb;  // allocation request
-//    initial alloc_stb = 1'b0;
-    reg free_stb;  // free request
-//    initial free_stb = 1'b0;
-    reg [15:0] free_addr;
-    initial begin
-        alloc_stb = 1'b0;
-        free_stb = 1'b0;
-        free_addr = UNDEF;
-        #1.2  // align for @(posedge clk)
-        #2  // wait 1 clock-cycle
-        alloc_stb = 1'b1;
-        #2
-        alloc_stb = 1'b0;
-        #4
-        alloc_stb = 1'b1;
-        #6
-        alloc_stb = 1'b0;
-        #2
-        free_stb = 1'b1;
-        free_addr = 16'h5001;
-        #2
-        free_addr = 16'h5003;
-        #2
-        free_stb = 1'b0;
-        free_addr = UNDEF;
-        alloc_stb = 1'b1;
-        #2
-        free_stb = 1'b1;
-        free_addr = 16'h5002;
-        #2
-        free_stb = 1'b0;
-        free_addr = UNDEF;
-        #2
-        alloc_stb = 1'b0;
-    end
 
 endmodule

--- a/Fomu/verilog/bench/alloc_test.v
+++ b/Fomu/verilog/bench/alloc_test.v
@@ -1,0 +1,116 @@
+/*
+
+Test component for the Linked-Memory Allocator
+
+    +---------------+
+    | alloc_test    |
+    |               |
+--->|i_en     o_pass|--->
+    |      o_running|--->
+    |               |
+ +->|i_clk          |
+ |  +---------------+
+
+This component runs some tests on alloc.v, producing a pass or fail result.
+Activity is paused whilst i_en is low. During operation, o_running remains
+high. Once o_running goes low, the value of o_pass indicates success or failure.
+
+*/
+
+`default_nettype none
+`include "alloc.v"
+
+module alloc_test (
+    input       i_clk,      // system clock
+    input       i_en,       // testing enabled
+    output      o_running,  // test in progress
+    output reg  o_pass      // test result
+);
+    localparam ADDR_SZ = 8;
+    localparam NIL = 16'h0001;
+
+// Whilst 'i_en' is high, the sequence counter increments every clock cycle
+// until the test is concluded.
+
+// Bits [ADDR_SZ-1:0] correspond to a cell count.
+// Bits [ADDR_SZ] and [ADDR_SZ+1] indicate the current phase of operation:
+
+//  00... Memory is being allocated.
+//  01... Memory is being read.
+//  10... The test has concluded.
+//  11... The allocator reported an error.
+
+    reg [ADDR_SZ+1:0] seq;
+    initial seq = 0;
+    wire allocating;
+    assign allocating = i_en && !seq[ADDR_SZ+1] && !seq[ADDR_SZ];
+    wire reading;
+    assign reading = i_en && !seq[ADDR_SZ+1] && seq[ADDR_SZ];
+    wire done;
+    assign done = seq[ADDR_SZ+1] && !seq[ADDR_SZ];
+    wire errored;
+    assign errored = seq[ADDR_SZ+1] && seq[ADDR_SZ];
+
+// The 'addr_rdy' and 'rdata_rdy' registers are high in cycles immediately
+// following an allocation or read operation.
+
+    reg addr_rdy;
+    initial addr_rdy = 0;
+    reg rdata_rdy;
+    initial rdata_rdy = 0;
+    always @(posedge i_clk) begin
+        addr_rdy <= allocating;
+        rdata_rdy <= reading;
+    end
+
+// During phase 1, cells are continually allocated to form a linked list ending
+// with NIL. At the moment the linked list completely fills memory, phase 2
+// begins. The linked list is then followed to its terminal value, which should
+// be NIL.
+
+// The test fails if the allocator reports an error at any time. It succeeds if
+// the linked list was the expected length and terminated in NIL.
+
+    initial o_pass = 0;
+    assign o_running = !seq[ADDR_SZ+1];
+    wire        err;
+    wire [15:0] addr;
+    wire [15:0] rdata;
+    alloc #(
+        .ADDR_SZ(8)
+    ) ALLOC (
+        .i_clk(i_clk),
+        .i_alloc(allocating),
+        .i_data(
+            addr_rdy
+            ? addr
+            : NIL
+        ),
+        .o_addr(addr),
+        .i_free(1'b0),
+        .i_addr(16'b0),
+        .i_wr(1'b0),
+        .i_waddr(16'b0),
+        .i_wdata(16'b0),
+        .i_rd(reading),
+        .i_raddr(
+            rdata_rdy
+            ? rdata
+            : addr
+        ),
+        .o_rdata(rdata),
+        .o_err(err)
+    );
+    always @(posedge i_clk) begin
+        if (err) begin
+            seq <= (16'b11 << ADDR_SZ);
+        end else if (!errored) begin
+            if (done && rdata == NIL) begin
+                o_pass <= 1;
+            end
+            if (i_en && !done) begin
+                seq <= seq + 1'b1;
+            end
+        end
+    end
+endmodule


### PR DESCRIPTION
A very basic test component for the allocator. It currently only tests allocation and read operations.

It does not pass, because of what I suspect is a bug in the allocator. It seems that `o_err` goes high the moment memory becomes full, rather than at a subsequent allocation. Is `o_err` supposed to act like a `mem_full` flag?

The test does pass if `ADDR_SZ` (on line 29 of alloc_test.v) is reduced, because then the memory is only partially filled.