### PR TITLE
Test allocator implementation

### DIFF
--- a/Fomu/verilog/bench/alloc.james.v
+++ b/Fomu/verilog/bench/alloc.james.v
@@ -1,0 +1,213 @@
+/*
+
+Linked-Memory Allocator
+
+    +---------------+
+    | alloc         |
+    |               |
+--->|i_alloc    i_wr|<---
+=N=>|i_data  i_wdata|<=N=
+<=N=|o_addr  i_waddr|<=N=
+    |               |
+--->|i_free     i_rd|<---
+=N=>|i_addr  i_raddr|<=N=
+    |        o_rdata|=N=>
+    |               |
+ +->|i_clk     o_err|--->
+ |  +---------------+
+
+This component manages a dynamically-allocated memory heap.
+It has two ports, with two functions each, and an error signal.
+Only one of the two ports may be used in any given cycle.
+All results are available on the next clock-cycle.
+Requests are pipelined and may be issued on every cycle.
+
+The first port manages heap-allocation pointers.
+An "alloc" request reserves a new address
+and stores an initial data value there.
+A "free" request returns memory to the heap.
+Both requests can be serviced in the same cycle.
+
+The second port is a simple memory-access interface.
+A "write" request stores data at a previously allocated address.
+A "read" request retrieves the last data stored at an address.
+
+If an error (such as out-of-memory) or invalid request occurs,
+the error signal is raised and the component halts.
+
+*/
+
+`default_nettype none
+
+`ifdef __ICARUS__
+`include "bram.v"
+`else
+`include "bram4k.v"
+`endif
+
+module alloc #(
+    // WARNING: hard-coded contants assume `DATA_SZ` = 16
+    parameter DATA_SZ           = 16,                           // number of bits per memory word
+    parameter ADDR_SZ           = 8,                            // number of bits in each address
+    parameter MEM_MAX           = (1<<ADDR_SZ)                  // maximum available physical memory
+) (
+    input                       i_clk,                          // domain clock
+
+    input                       i_alloc,                        // allocation request
+    input         [DATA_SZ-1:0] i_data,                         // initial data
+    output reg    [DATA_SZ-1:0] o_addr,                         // allocated address
+
+    input                       i_free,                         // free request
+    input         [DATA_SZ-1:0] i_addr,                         // free address
+
+    input                       i_wr,                           // write request
+    input         [DATA_SZ-1:0] i_waddr,                        // write address
+    input         [DATA_SZ-1:0] i_wdata,                        // data written
+
+    input                       i_rd,                           // read request
+    input         [DATA_SZ-1:0] i_raddr,                        // read address
+    output reg    [DATA_SZ-1:0] o_rdata,                        // data read
+
+    output reg                  o_err                           // error condition
+);
+
+    // type-tags
+    localparam DIR_TAG          = 16'h8000;                     // direct(fixnum) or indirect(ptr)
+    localparam MUT_TAG          = 16'h4000;                     // mutable or immutable(rom)
+    localparam OPQ_TAG          = 16'h2000;                     // opaque(cap) or transparent(ram)
+    localparam VLT_TAG          = 16'h1000;                     // volatile or reserved
+
+    // reserved constants
+    localparam UNDEF            = 16'h0000;                     // undefined value
+    localparam NIL              = 16'h0001;                     // the empty list
+    localparam TRUE             = 16'h0002;                     // boolean true
+    localparam FALSE            = 16'h0003;                     // boolean false
+    localparam UNIT             = 16'h0004;                     // inert result
+    localparam ZERO             = 16'h8000;                     // fixnum +0
+
+    initial o_addr = UNDEF;
+    initial o_rdata = UNDEF;
+    initial o_err = 1'b0;
+
+    wire mem_op = i_alloc || i_free;
+    wire ptr_op = i_rd || i_wr;
+    wire bad_op = mem_op && ptr_op;
+    wire read_op = i_rd && !mem_op;
+    wire write_op = i_wr && !mem_op;
+    wire alloc_op = i_alloc && !ptr_op;
+    wire free_op = i_free && !ptr_op;
+
+    // top of available memory
+    reg [DATA_SZ-1:0] mem_top = (MUT_TAG | VLT_TAG);
+    // NOTE: extra bit for overflow check
+    wire [ADDR_SZ:0] next_top = {1'b0, mem_top[ADDR_SZ-1:0]} + 1'b1;
+    wire mem_full = next_top[ADDR_SZ];
+
+    // next memory cell on free-list
+    reg [DATA_SZ-1:0] mem_next = NIL;
+
+    // count of cells on free-list (always non-negative)
+    reg [ADDR_SZ-1:0] mem_free = 0;
+    // cells are available on the free-list
+    wire free_f = mem_next[14];  // check MUT_TAG;
+//    wire free_f = (mem_free == 0);
+
+    // raise the memory ceiling?
+    wire raise_top = alloc_op && !free_op && !free_f;
+
+    // whether a cell is being pushed onto or popped from the free list
+    wire pop_free_op = alloc_op && !free_op && free_f;
+    wire push_free_op = free_op && !alloc_op;
+
+    // receives the data arriving on the negative clock edge
+    wire [DATA_SZ-1:0] rdata;
+
+    // are we retrieving mem_next from memory?
+    reg rnext = 0;
+
+    // FIXME: tighter error handling?
+
+    bram BRAM (
+        .i_clk(i_clk),
+        .i_wr_en(alloc_op || free_op || write_op),
+        .i_waddr(
+            free_op
+            ? i_addr[ADDR_SZ-1:0] // if also alloc_op, assign passed-thru memory
+            : (
+                alloc_op
+                ? (
+                    free_f
+                    ? mem_next[ADDR_SZ-1:0]
+                    : mem_top[ADDR_SZ-1:0]
+                )
+                : i_waddr[ADDR_SZ-1:0]
+            )
+        ),
+        .i_wdata(
+            alloc_op
+            ? i_data
+            : (
+                free_op
+                ? mem_next
+                : i_wdata
+            )
+        ),
+        .i_rd_en(read_op || pop_free_op),
+        .i_raddr(
+            pop_free_op
+            ? mem_next[ADDR_SZ-1:0]
+            : i_raddr[ADDR_SZ-1:0]
+        ),
+        .o_rdata(rdata)
+    );
+
+    always @(posedge i_clk) begin
+        // check for error conditions
+        if (o_err || bad_op || (raise_top && mem_full)) begin
+            o_err <= 1; // sticky
+        end else begin
+            // erase any data read during the previous clock
+            o_rdata <= UNDEF;
+            // register the allocated address
+            o_addr <= (
+                alloc_op
+                ? (
+                    free_op
+                    ? i_addr
+                    : (
+                        free_f
+                        ? mem_next
+                        : mem_top
+                    )
+                )
+                : UNDEF
+            );
+            // registered so that inputs need not be maintained thru the negedge
+            // FIXME: or can we rely on the input signals being stable for the whole cycle?
+            rnext <= pop_free_op;
+            // maintain free list counter
+            if (pop_free_op) begin
+                mem_free <= mem_free - 1'b1;
+            end else if (push_free_op) begin
+                mem_free <= mem_free + 1'b1;
+            end
+            // increment memory top marker
+            if (raise_top && !mem_full) begin
+                mem_top <= {mem_top[DATA_SZ-1:ADDR_SZ+1], next_top};
+            end
+            // if a cell is freed, add it to the free list
+            if (free_op && !alloc_op) begin
+                mem_next <= i_addr;
+            end
+        end
+    end
+
+    // on the negedge, register data arriving from memory
+    always @(negedge i_clk) begin
+        if (rnext) begin
+            mem_next <= rdata;
+        end else begin
+            o_rdata <= rdata;
+        end
+    end
+endmodule

--- a/Fomu/verilog/bench/alloc_tb.v
+++ b/Fomu/verilog/bench/alloc_tb.v
@@ -6,8 +6,8 @@ Test Bench for alloc.v
 
 `default_nettype none
 
-//`include "alloc_test.v"
-`include "fixture.v"
+`include "alloc_test.v"
+// `include "fixture.v"
 
 `timescale 10ns/1ns
 

--- a/Fomu/verilog/bench/top.v
+++ b/Fomu/verilog/bench/top.v
@@ -6,8 +6,8 @@ Physical Test Bench
 
 `default_nettype none
 
-//`include "alloc_test.v"
-`include "fixture.v"
+`include "alloc_test.v"
+// `include "fixture.v"
 
 module top (
     input                       clki,                           // 48MHz oscillator input on Fomu-PVT


### PR DESCRIPTION
I noticed that alloc_test.v was failing in the simulator. It appears that alloc.v's `o_rdata` output signal is delayed an extra cycle, which you can see the consequences of here:

<img width="1234" alt="image" src="https://github.com/dalnefre/FPGA/assets/86713508/345a3ca0-9c2b-46cc-81b3-0d47389d748a">

Notice how `o_rdata` goes haywire once `seq` reaches 12.

This is what it's supposed to look like:

<img width="1235" alt="image" src="https://github.com/dalnefre/FPGA/assets/86713508/fbb2f612-c145-4e0e-a195-e8746191b2df">

(And actually, this is what I see when I run alloc_test.v on alloc.james.v in the simulator).