### PR TITLE
Test read/write/alloc/free

### DIFF
--- a/Fomu/verilog/bench/alloc_tb.v
+++ b/Fomu/verilog/bench/alloc_tb.v
@@ -17,7 +17,7 @@ module test_bench;
     initial begin
         $dumpfile("alloc.vcd");
         $dumpvars(0, test_bench);
-        #1000;
+        #4200;
         $finish;
     end
 


### PR DESCRIPTION
This commit enhances alloc_test.v to test allocation, freeing, reading, and writing. Simultaneous reading and writing is tested, but not simultaneous allocating and freeing.

Building alloc_test.v+alloc.james.v scrapes by at 49MHz, compared to 53MHz for alloc_test.v+alloc.v.

In the simulator, both alloc.v and alloc.james.v pass alloc_test.v with reduced address sizes. Oddly, alloc.v supports ADDR_SZ<=6 whereas alloc.james.v supports ADDR_SZ<=7.