### PR TITLE
Quad allocator

### DIFF
--- a/Fomu/verilog/bench/alloc.james.v
+++ b/Fomu/verilog/bench/alloc.james.v
@@ -1,17 +1,17 @@
 /*
 
-A linked-memory allocator with configurable address and data sizes.
+A linked-memory quad allocator with configurable address and field sizes.
 
     +-----------------+
     | alloc           |
     |                 |
 --->|i_al         i_wr|<---
-=N=>|i_adata   i_waddr|<=N=
-<=N=|o_aaddr   i_wdata|<=N=
+=Q=>|i_adata   i_waddr|<=F=
+<=F=|o_aaddr   i_wdata|<=Q=
     |                 |
 --->|i_fr         i_rd|<---
-=N=>|i_faddr   i_raddr|<=N=
-    |          o_rdata|=N=>
+=F=>|i_faddr   i_raddr|<=F=
+    |          o_rdata|=Q=>
     |                 |
  +->|i_clk      o_full|--->
  |  +-----------------+
@@ -25,34 +25,44 @@ Requests are pipelined and may be issued on every cycle.
 
 The first port manages heap-allocation pointers.
 An "alloc" request reserves a new address
-and stores an initial data value there.
+and stores an initial quad there.
 A "free" request returns memory to the heap.
 Both requests can be serviced in the same cycle.
 A "free" request must accompany an "alloc" request
 if the memory is full.
 
 The second port is a simple memory-access interface.
-A "write" request stores data at a previously allocated address.
-A "read" request retrieves the last data stored at an address.
+A "write" request stores a quad at a previously allocated address.
+A "read" request retrieves the last quad stored at an address.
 
 If an invalid request is issued, such as alloc-on-full or read+free,
-the component will move to an undefined state.
+the state of the component will become undefined.
 
-This component comprises a number of 4kb memory blocks arranged in a single row.
+A quad consists of four sequential fields, T, X, Y, and Z.
+There are four fields in a quad.
+Each field is a tagged value.
+
+    <--------------- QUAD_SZ --------------->
+    +---------+---------+---------+---------+
+    |    T    |    X    |    Y    |    Z    |
+    +---------+---------+---------+---------+
+    <--------->
+      FIELD_SZ
+
+The allocator's storage comprises a number of 4kb memory blocks
+arranged in a single row.
 A single row seems to give better performance than a grid arrangement.
-The width of each memory cell (DATA_SZ) is the combined width of all blocks.
+The block size is independent of the field size.
+The total width of the row is the width of a quad.
 
-                       DATA_SZ
-    |----------------------------------------|
-
-    +--------+   +--------+         +--------+   ---
-    |        |   |        |         |        |    |
-    |   4k   |   |   4k   |   ...   |   4k   |    | 2^ADDR_SZ
-    |        |   |        |         |        |    |
-    +--------+   +--------+         +--------+   ---
-
-                                    |--------|
-                                    BLK_DATA_SZ
+    <---------------- QUAD_SZ -------------->
+    +--------+   +--------+        +--------+  ^
+    |        |   |        |        |        |  |
+    |   4k   |   |   4k   |  ....  |   4k   |  | 2^ADDR_SZ
+    |        |   |        |        |        |  |
+    +--------+   +--------+        +--------+  v
+                                   <-------->
+                                   BLK_DATA_SZ
 */
 
 `default_nettype none
@@ -64,8 +74,8 @@ The width of each memory cell (DATA_SZ) is the combined width of all blocks.
 `endif
 
 module alloc #(
-    parameter ADDR_SZ = 8,                  // number of bits in each address
-    parameter DATA_SZ = 16,                 // memory cell size in bits, not less than ADDR_SZ
+    parameter FIELD_SZ = 16,                // number of bits in a tagged value
+    parameter ADDR_SZ = 8,                  // log2(size of the address space), not more than FIELD_SZ-4
     // The following parameters can be adjusted for testing purposes. The
     // quantity BLK_DATA_SZ * 2^ADDR_SZ must not exceed 4096.
     parameter BLK_DATA_SZ = 16              // memory cell size in bits, per block
@@ -73,23 +83,34 @@ module alloc #(
     input                       i_clk,      // domain clock
 
     input                       i_al,       // allocation request
-    input         [DATA_SZ-1:0] i_adata,    // initial data
-    output reg    [ADDR_SZ-1:0] o_aaddr,    // allocated address
+    input       [QUAD_SZ-1:0]   i_adata,    // initial data
+    output reg  [FIELD_SZ-1:0]  o_aaddr,    // allocated address
 
     input                       i_fr,       // free request
-    input         [ADDR_SZ-1:0] i_faddr,    // free address
+    input       [FIELD_SZ-1:0]  i_faddr,    // free address
 
     input                       i_wr,       // write request
-    input         [ADDR_SZ-1:0] i_waddr,    // write address
-    input         [DATA_SZ-1:0] i_wdata,    // data written
+    input       [FIELD_SZ-1:0]  i_waddr,    // write address
+    input       [QUAD_SZ-1:0]   i_wdata,    // data written
 
     input                       i_rd,       // read request
-    input         [ADDR_SZ-1:0] i_raddr,    // read address
-    output        [DATA_SZ-1:0] o_rdata,    // data read
+    input       [FIELD_SZ-1:0]  i_raddr,    // read address
+    output      [QUAD_SZ-1:0]   o_rdata,    // data read
 
     output                      o_full      // memory full condition
 );
-    localparam NR_BLKS = DATA_SZ / BLK_DATA_SZ;
+    localparam QUAD_SZ = 4 * FIELD_SZ;      // memory cell size in bits
+    localparam NR_BLKS = QUAD_SZ / BLK_DATA_SZ;
+
+    // type tags
+    localparam DIR_TAG = 1 << 3;    // direct(fixnum) or indirect(ptr)
+    localparam MUT_TAG = 1 << 2;    // mutable or immutable(rom)
+    localparam OPQ_TAG = 1 << 1;    // opaque(cap) or transparent(ram)
+    localparam VLT_TAG = 1;         // volatile or reserved
+    localparam RAM_TAG = MUT_TAG | VLT_TAG;
+    localparam BASE = RAM_TAG << (FIELD_SZ-4);
+    localparam FREE_T = 15;         // T field for a quad in the free list
+    localparam FREE_QUAD = (FREE_T << (3*FIELD_SZ)) | BASE; // [T ... Z]
 
     // top of available memory
     reg [ADDR_SZ:0] mem_top = 0;
@@ -116,33 +137,34 @@ module alloc #(
     wire rd_en = i_rd || pop_free;
 
     // the data read from BRAM
-    wire [DATA_SZ-1:0] rdata;
+    wire [QUAD_SZ-1:0] rdata;
 
     // next memory cell on free-list
-    reg [DATA_SZ-1:0] r_mem_next = 0;
-    wire [DATA_SZ-1:0] mem_next = (
+    reg [ADDR_SZ-1:0] r_mem_next = 0;
+    wire [ADDR_SZ-1:0] mem_next = (
         r_pop_freed
-        ? rdata
+        ? rdata[ADDR_SZ-1:0]
         : r_mem_next
     );
+    wire [QUAD_SZ-1:0] fdata = FREE_QUAD | mem_next; // [FREE_T, #?, #?, Z]
 
     // determine the abstract memory locations to read/write
     wire [ADDR_SZ-1:0] waddr = (
         i_fr
-        ? i_faddr // if also i_al, assign passed-thru memory
+        ? i_faddr[ADDR_SZ-1:0] // if also i_al, assign passed-thru memory
         : (
             i_al
             ? (
                 free_f
-                ? mem_next[ADDR_SZ-1:0]
+                ? mem_next
                 : mem_top[ADDR_SZ-1:0]
             )
-            : i_waddr
+            : i_waddr[ADDR_SZ-1:0]
         )
     );
     wire [ADDR_SZ-1:0] raddr = (
         pop_free
-        ? mem_next[ADDR_SZ-1:0]
+        ? mem_next
         : i_raddr
     );
 
@@ -157,31 +179,31 @@ module alloc #(
         ) BRAM (
             .i_clk(i_clk),
             .i_wr_en(wr_en),
-            .i_waddr(waddr[ADDR_SZ-1:0]),
+            .i_waddr(waddr),
             .i_wdata(
                 i_al
                 ? i_adata[ms:ls]
                 : (
                     i_fr
-                    ? mem_next[ms:ls]
+                    ? fdata[ms:ls]
                     : i_wdata[ms:ls]
                 )
             ),
             .i_rd_en(rd_en),
-            .i_raddr(raddr[ADDR_SZ-1:0]),
+            .i_raddr(raddr),
             .o_rdata(rdata[ms:ls])
         );
     end
 
     assign o_rdata = rdata;
     always @(posedge i_clk) begin
-        // register the allocated address (garbage if i_al if low)
-        o_aaddr <= (
+        // register the allocated address (garbage if i_al is low)
+        o_aaddr <= BASE | (
             i_fr
             ? i_faddr
             : (
                 free_f
-                ? mem_next[ADDR_SZ-1:0]
+                ? mem_next
                 : mem_top[ADDR_SZ-1:0]
             )
         );
@@ -191,11 +213,11 @@ module alloc #(
         end
         // maintain the free list
         if (r_pop_freed) begin
-            r_mem_next <= rdata; // pop
+            r_mem_next <= rdata[ADDR_SZ-1:0]; // pop
         end
         r_pop_freed <= pop_free;
         if (push_free) begin
-            r_mem_next <= i_faddr; // push
+            r_mem_next <= i_faddr[ADDR_SZ-1:0]; // push
         end
         // maintain free list counter
         if (pop_free) begin

--- a/Fomu/verilog/bench/alloc_tb.v
+++ b/Fomu/verilog/bench/alloc_tb.v
@@ -17,7 +17,7 @@ module test_bench;
     initial begin
         $dumpfile("alloc.vcd");
         $dumpvars(0, test_bench);
-        #40000;
+        #20000;
         $finish;
     end
 


### PR DESCRIPTION
The free list comprises FREE_T quads. Addresses are correctly tagged.

Currently fails in the simulator due to the recently introduced write-before-read semantics in bram.v, but it might pass on the Fomu.